### PR TITLE
Error checking to avoid exceptions

### DIFF
--- a/java/src/com/google/typography/font/sfntly/table/opentype/component/RuleSegment.java
+++ b/java/src/com/google/typography/font/sfntly/table/opentype/component/RuleSegment.java
@@ -12,15 +12,20 @@ class RuleSegment extends LinkedList<GlyphGroup> {
   }
 
   RuleSegment(GlyphGroup glyphGroup) {
-    addInternal(glyphGroup);
+    if (glyphGroup != null)
+        addInternal(glyphGroup);
   }
 
   RuleSegment(int glyph) {
+    if (glyph < 0)
+      return;
     GlyphGroup glyphGroup = new GlyphGroup(glyph);
     addInternal(glyphGroup);
   }
 
   RuleSegment(GlyphList glyphs) {
+    if (glyphs == null)
+      return;
     for (int glyph : glyphs) {
       GlyphGroup glyphGroup = new GlyphGroup(glyph);
       addInternal(glyphGroup);


### PR DESCRIPTION
In this case the parameterless constructor is valid and so checking the arguments for invalid parameters is required. Some of the Noto fonts cannot be loaded by FontViewer tool without these checks.