### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+# Directories #
+java/build/
+java/bin/
+java/target/
+workfiles/
+
+# Temps and Backups #
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+
+# Package Files #
+*.jar
+*.war
+*.ear
+*.db
+
+# Windows
+Thumbs.db
+Desktop.ini
+
+# OSX
+.DS_Store
+
+######################
+# NetBeans
+######################
+ant_nbproject/
+ant_build.xml
+nb-configuration.xml
+
+######################
+# Eclipse
+######################
+java/.metadata/
+java/.recommenders/
+java/.settings/
+java/.classpath
+java/.project
+
+######################
+# Java
+######################
+*.class


### PR DESCRIPTION
A .gitignore is useful in any git-controlled project. This .gitignore excludes from control some files and folders commonly auto-generated by editors and/or OS's, as well as the project files generated by IDE's like Eclipse and NetBeans.

Of course, more can always be added.